### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- grant write permissions for GitHub Pages deployment

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684acb0a87e4832e9213c3c7f820cf40