### PR TITLE
Fix GitHub link security attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
           <h2>Contact</h2>
           <p><i class="fa-solid fa-envelope"></i> <a :href="`mailto:${email}`">{{ email }}</a></p>
           <p><i class="fa-solid fa-phone"></i> <a :href="`tel:${phone}`">{{ phone }}</a></p>
-          <p><i class="fa-brands fa-github"></i> <a :href="github" target="_blank">GitHub</a></p>
+          <p><i class="fa-brands fa-github"></i> <a :href="github" target="_blank" rel="noopener noreferrer">GitHub</a></p>
         </section>
       </transition>
     </main>


### PR DESCRIPTION
## Summary
- secure the external GitHub link by adding `rel="noopener noreferrer"`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6853c546281c832e8fd5b09de73e4579