### PR TITLE
Improve nav link highlighting

### DIFF
--- a/main.js
+++ b/main.js
@@ -152,6 +152,11 @@ createApp({
 const navLinks = document.querySelectorAll('.page-nav a');
 const sections = document.querySelectorAll('main section[id]');
 
+// highlight the first navigation link on initial load
+if (navLinks.length) {
+  navLinks[0].classList.add('active');
+}
+
 const observer = new IntersectionObserver(
   entries => {
     entries.forEach(entry => {


### PR DESCRIPTION
## Summary
- highlight first nav link on page load so navigation always shows an active section

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ac40b7d1c832e90b34ea32dee3df6