### PR TITLE
Add tests for README and instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 
 # Logs
 npm-debug.log*
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ include a photo, you can remove the `<img>` tag entirely.
 
 Before sharing the page publicly, you may remove or anonymize sensitive data
 from `main.js` such as your phone number or email address.
+
+## Running Tests
+To run the Python unit tests, execute:
+
+```bash
+python -m unittest
+```
+
+This will run all tests found in the `tests/` folder.

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,13 @@
+import os
+import unittest
+
+class TestREADME(unittest.TestCase):
+    def test_readme_exists_and_not_empty(self):
+        path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'README.md')
+        self.assertTrue(os.path.exists(path), 'README.md should exist')
+        with open(path, 'r', encoding='utf-8') as f:
+            content = f.read().strip()
+        self.assertTrue(len(content) > 0, 'README.md should not be empty')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Python unittest verifying `README.md` exists and is non-empty
- ignore `__pycache__` directories
- document how to run the tests

## Testing
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_6853d0624fa4832ea40a6f515fac076d