### PR TITLE
[feat] Add fixed Codex AI banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,9 +108,12 @@
           <p><i class="fa-solid fa-phone"></i> <a :href="`tel:${phone}`">{{ phone }}</a></p>
           <p><i class="fa-brands fa-github"></i> <a :href="github" target="_blank" rel="noopener noreferrer">GitHub</a></p>
         </section>
-      </transition>
+  </transition>
     </main>
   </div>
+  <a id="codex-banner" href="https://github.com/chungchung234/cover_letter" target="_blank" class="fixed bottom-4 right-4 bg-gray-800 text-white text-xs px-3 py-2 rounded shadow-lg z-50">
+    보고계신 페이지는 코딩 없이 Codex AI로 생성된 페이지입니다.
+  </a>
   <script src="main.js" defer></script>
   <script>
     if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- show a persistent banner at the bottom right linking to the GitHub repo

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_6853df6793a0832e9ff69d67465a0bf9