### PR TITLE
[feat] remember dark mode preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This is a minimal Vue-based site for a personal cover letter. The page uses Tail
 Open `index.html` in a browser to see the page. The site automatically matches
 your operating system's light or dark mode. You can also use the **dark mode**
 button to switch themes manually and the **contact toggle** to reveal a styled
-contact card with your email, phone, and address.
+contact card with your email, phone, and address. The selected mode is saved to
+local storage so your preference is kept when you reload the page.
 
 ## Deploy to GitHub Pages
 1. Push the contents of this repository to GitHub.

--- a/main.js
+++ b/main.js
@@ -97,6 +97,7 @@ const app = createApp({
 
     const toggleDarkMode = () => {
       isDark.value = !isDark.value;
+      localStorage.setItem('theme', isDark.value ? 'dark' : 'light');
     };
     const toggleContact = () => {
       showContact.value = !showContact.value;
@@ -118,17 +119,22 @@ const app = createApp({
 
     let schemeHandler = null;
    onMounted(() => {
-      const mql = window.matchMedia('(prefers-color-scheme: dark)');
-      isDark.value = mql.matches;
-      const handler = (e) => {
-        isDark.value = e.matches;
-      };
-      if (mql.addEventListener) {
-        mql.addEventListener('change', handler);
-      } else if (mql.addListener) {
-        mql.addListener(handler);
+      const stored = localStorage.getItem('theme');
+      if (stored === 'dark' || stored === 'light') {
+        isDark.value = stored === 'dark';
+      } else {
+        const mql = window.matchMedia('(prefers-color-scheme: dark)');
+        isDark.value = mql.matches;
+        const handler = (e) => {
+          isDark.value = e.matches;
+        };
+        if (mql.addEventListener) {
+          mql.addEventListener('change', handler);
+        } else if (mql.addListener) {
+          mql.addListener(handler);
+        }
+        schemeHandler = { mql, handler };
       }
-      schemeHandler = { mql, handler };
       window.addEventListener('scroll', handleScroll);
     });
 


### PR DESCRIPTION
## Summary
- persist user's chosen theme in `localStorage`
- describe the saved theme behavior in the README

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_6853e97e8158832ebeae1d914ee6420e