### PR TITLE
[feat] dark mode toggle icon and relocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This is a minimal Vue-based site for a personal cover letter. The page uses Tail
 
 ## Local Preview
 Open `index.html` in a browser to see the page. The site automatically matches
-your operating system's light or dark mode. You can also use the **dark mode**
-button to switch themes manually and the **contact toggle** to reveal a styled
-contact card with your email, phone, and address. The selected mode is saved to
-local storage so your preference is kept when you reload the page.
+your operating system's light or dark mode. A **dark mode** toggle with a
+sun/moon icon is fixed to the top right corner for quick access. Use it to
+switch themes manually and the **contact toggle** to reveal a styled contact
+card with your email, phone, and address. The selected mode is saved to local
+storage so your preference is kept when you reload the page.
 
 ## Deploy to GitHub Pages
 1. Push the contents of this repository to GitHub.

--- a/index.html
+++ b/index.html
@@ -42,11 +42,16 @@
 <body>
   <div id="app-root">
     <div id="app" :class="{ dark: isDark }" class="mx-auto p-4 sm:p-6 lg:p-8 max-w-3xl sm:max-w-4xl lg:max-w-6xl bg-background text-text-main rounded-lg shadow">
+    <button
+      @click="toggleDarkMode"
+      class="mode-toggle fixed top-4 right-4 bg-brand text-white p-2 rounded-full shadow-lg hover:bg-brand/90 flex items-center gap-1 transition-colors duration-300"
+      aria-label="다크 모드 전환"
+    >
+      <i :class="isDark ? 'fa-solid fa-sun' : 'fa-solid fa-moon'"></i>
+      <span class="hidden sm:inline">{{ isDark ? '라이트 모드' : '다크 모드' }}</span>
+    </button>
     <header class="text-center mb-8">
       <h1 class="text-3xl sm:text-4xl font-bold mb-1">{{ name }} | {{ role }}</h1>
-      <button @click="toggleDarkMode" class="mode-toggle mt-3 px-3 py-1 bg-brand text-white rounded hover:bg-brand/90 transition-colors duration-300">
-        {{ isDark ? '라이트 모드' : '다크 모드' }}
-      </button>
       <button @click="toggleContact" class="contact-toggle mt-2 px-3 py-1 bg-link text-white rounded hover:bg-hover-btn flex items-center gap-1 transition-colors duration-300">
         <i class="fa-solid fa-address-book"></i>
         {{ showContact ? '연락처 숨기기' : '연락처 보기' }}


### PR DESCRIPTION
## Summary
- relocate the dark mode button to the top right corner
- add sun/moon icon for clarity
- document button placement in README

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_6853ed5d7210832e9003c7cd716c1d5f