### PR TITLE
[fix] adjust service worker paths

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,11 +1,11 @@
 const CACHE_NAME = 'cover-letter-cache-v1';
 const ASSETS = [
   '/',
-  '/index.html',
-  '/style.css',
-  '/main.js',
-  '/manifest.json',
-  '/profile.jpg'
+  'index.html',
+  'style.css',
+  'main.js',
+  'manifest.json',
+  'profile.jpg'
 ];
 self.addEventListener('install', event => {
   event.waitUntil(


### PR DESCRIPTION
## Summary
- switch to relative paths in `ASSETS` list

## Testing
- `python -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_6853f7be7930832ea2261f3846a732ae