### PR TITLE
[fix] remove duplicate GitHub address

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,10 +75,6 @@
               <i class="fa-brands fa-github"></i>
               <a :href="github" target="_blank" rel="noopener noreferrer" class="hover:underline">GitHub</a>
             </p>
-            <p class="mt-1 flex items-center gap-2">
-              <i class="fa-solid fa-globe"></i>
-              <a href="https://github.com/chungchung234/" target="_blank" rel="noopener noreferrer" class="hover:underline">GitHub 페이지</a>
-            </p>
           </section>
         </transition>
       </header>


### PR DESCRIPTION
## Summary
- remove the extra GitHub page link from the contact section

## Testing
- `python -m unittest discover -v tests`


------
https://chatgpt.com/codex/tasks/task_e_6853f7f3a9f8832ea2f082cddebf213d