### PR TITLE
[feat] add taegukgi icon to color info

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
           </section>
         </transition>
       </header>
+<p class="color-info text-center text-sm mb-4"><span class="flag-icon" role="img" aria-label="태극기">🇰🇷</span> 메인 컬러는 태극기의 흰 배경과 태극 무늬, 건곤감리를 각 비율에 맞춰 mix한 <span class="color-tooltip text-brand font-mono">#C7B9C7<span class="tooltip">다른 색상: #DAD2DA, #B5A4B5, #9C849C</span></span> 컬러를 사용합니다.</p>
     <nav class="page-nav sticky top-0 z-50 bg-sub-bg dark:bg-dark-card-bg p-2 shadow">
       <div class="sm:hidden flex justify-end">
         <button @click="toggleNav" class="text-text-sub dark:text-dark-text-sub text-xl px-2 py-1">

--- a/style.css
+++ b/style.css
@@ -74,3 +74,29 @@ main section {
   margin-bottom: 2rem;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
+.color-tooltip {
+  position: relative;
+  cursor: pointer;
+}
+
+.color-tooltip .tooltip {
+  display: none;
+  position: absolute;
+  left: 50%;
+  bottom: -1.75rem;
+  transform: translateX(-50%);
+  background-color: var(--color-card-bg);
+  color: var(--color-text-main);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  border-radius: 0.25rem;
+  white-space: nowrap;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.color-tooltip:hover .tooltip {
+  display: block;
+}
+.flag-icon {
+  margin-right: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- show Korean flag icon next to color description
- style icon with small margin

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853fd19f80c832e9dad44627a90db05