### PR TITLE
[fix] 기술 스택 그리드 UI 개선 및 아이콘 표시

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,9 +110,13 @@
         <div v-for="group in techStack" :key="group.category" class="mb-4">
           <h3 class="font-semibold mb-1">{{ group.category }}</h3>
           <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
-            <div v-for="skill in group.skills" :key="skill.name" class="flex items-center gap-1">
-              <i v-if="skill.icon" :class="['text-lg', skill.icon]"></i>
-              <span>{{ skill.name }}</span>
+            <div
+              v-for="skill in group.skills"
+              :key="skill.name"
+              class="flex items-center gap-2 px-2 py-1 rounded bg-sub-bg/60 dark:bg-dark-card-bg/70 border border-border"
+            >
+              <i v-if="skill.icon" :class="['text-brand', 'fa-fw', skill.icon]"></i>
+              <span class="text-sm">{{ skill.name }}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- improve visibility of skill grid items
- fix icons not showing in tech stack section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540103ac34832ebd5f9825213ebfbb